### PR TITLE
Deprecate legacy plugins portal (Grails 1 & 2)

### DIFF
--- a/grails-app/controllers/grailsplugins/PluginController.groovy
+++ b/grails-app/controllers/grailsplugins/PluginController.groovy
@@ -12,11 +12,11 @@ class PluginController implements GrailsConfigurationAware {
             refresh: 'POST',
             plugin: 'GET',
             pluginWithOwner: 'GET',
+            legacyPlugins: 'GET'
     ]
 
     GrailsPluginsRepository grailsPluginsRepository
     GrailsPluginsService grailsPluginsService
-
 
     boolean refreshEnabled
 
@@ -41,6 +41,17 @@ class PluginController implements GrailsConfigurationAware {
                 pluginTotal: total,
                 topRatedPlugins: grailsPluginsRepository.topRatedPlugins(),
                 latestPlugins: grailsPluginsRepository.latestPlugins(),
+        ])
+    }
+
+    def legacyPlugins() {
+        List<GrailsPlugin> pluginList = grailsPluginsRepository.findAll()
+        render(view: 'legacyPlugins', model: [
+            pluginList: pluginList,
+            query: null,
+            pluginTotal: pluginList.size(),
+            topRatedPlugins: grailsPluginsRepository.topRatedPlugins(),
+            latestPlugins: grailsPluginsRepository.latestPlugins(),
         ])
     }
 

--- a/grails-app/controllers/grailsplugins/UrlMappings.groovy
+++ b/grails-app/controllers/grailsplugins/UrlMappings.groovy
@@ -4,6 +4,7 @@ class UrlMappings {
 
     static mappings = {
         "/"(controller: 'plugin', action: 'index')
+        "/legacy-plugins"(controller: 'plugin', action: 'legacyPlugins')
         "/plugin/json"(controller: 'plugin', action: 'json')
         "/plugin/refresh"(controller: 'plugin', action: 'refresh')
         "/plugin/$pluginName"(controller: 'plugin', action: 'plugin')

--- a/grails-app/views/plugin/legacyPlugins.gsp
+++ b/grails-app/views/plugin/legacyPlugins.gsp
@@ -10,8 +10,8 @@
         <div class="column">
             <div class="plugins-list">
 
-                <p>The Grails 1 & 2 plugins portal has been deprecated and it doesn't allow to submit new plugins anymore.</p>
-                <p>If you need to find old plugins you can use your favorite search engine.</p>
+                <p>The Grails 1 & 2 plugin portal is no longer active.  We are not accepting submissions for new plugins for Grails 1 & 2.</p>
+                <p>Documentation for Grails 1 & 2 plugins can be found on the website or source code repository of each plugin.  If you require additional assitance, please visit the Grails <a href="https://grails.org/support.html">support page</a>.</p>
 
             </div>
         </div>

--- a/grails-app/views/plugin/legacyPlugins.gsp
+++ b/grails-app/views/plugin/legacyPlugins.gsp
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="layout" content="main" />
+</head>
+<body class="grails3plugins">
+<content tag="title">plugins</content>
+<article>
+    <div class="goldenratio">
+        <div class="column">
+            <div class="plugins-list">
+
+                <p>The Grails 1 & 2 plugins portal has been deprecated and it doesn't allow to submit new plugins anymore.</p>
+                <p>If you need to find old plugins you can use your favorite search engine.</p>
+
+            </div>
+        </div>
+        <div class="column">
+            <g:render template="/templates/menu" model="[active:'legacy']"/>
+            <div class="latestguides">
+                <h3 class="columnheader">Latest Plugins</h3>
+                <ul>
+                <g:each var="plugin" in="${latestPlugins}">
+                    <li>
+                    <b>${plugin.bintrayPackage?.name} </b>
+                    <span><grailsplugins:lastUpdated plugin="${plugin}"/></span>
+                        <g:render template="pluginlink" model="[plugin: plugin, text: 'Read More']"/>
+                    </li>
+                </g:each>
+                </ul>
+            </div>
+            <div class="latestguides">
+                <h3 class="columnheader">Top Rated Plugins</h3>
+                <ul>
+                    <g:each var="plugin" in="${topRatedPlugins}">
+                        <li>
+                            <b>${plugin.bintrayPackage?.name} </b>
+                            <span><asset:image src="small_githubstar.svg" alt="Github"/> ${plugin.githubRepository?.stargazersCount}</span>
+                            <g:render template="pluginlink" model="[plugin: plugin, text: 'Read More']"/>
+                        </li>
+                    </g:each>
+                </ul>
+            </div>
+            <g:if test="${!query}">
+                <grailsplugins:labelsTagCloud pluginList="${pluginList}"/>
+                <grailsplugins:ownersTagCloud pluginList="${pluginList}"/>
+                <g:render template="twitterTimeline"/>
+            </g:if>
+        </div>
+    </div>
+</article>
+    </body>
+</html>

--- a/grails-app/views/templates/_menu.gsp
+++ b/grails-app/views/templates/_menu.gsp
@@ -1,7 +1,15 @@
 <nav class="thirdmenu">
     <ul>
-        <li class="active"><a href="http://plugins.grails.org/"><g:message code="nav.grails3plugins" default="Current Plugins (Grails 3 & 4)"/></a></li>
-        <li><a href="https://grails.org/plugins/"><g:message code="nav.grails2plugins" default="Legacy Plugins (Grails 1 & 2)"/></a></li>
+        <g:set var="activePlugins" value="active" />
+        <g:set var="activeLegacy" value="" />
+
+        <g:if test="${active == 'legacy'}">
+            <g:set var="activePlugins" value="" />
+            <g:set var="activeLegacy" value="active" />
+        </g:if>
+
+        <li class="${activePlugins}"><a href="http://plugins.grails.org/"><g:message code="nav.grails3plugins" default="Current Plugins (Grails 3 & 4)"/></a></li>
+        <li class="${activeLegacy}"><g:link controller="plugin" action="legacyPlugins"><g:message code="nav.grails2plugins" default="Legacy Plugins (Grails 1 & 2)"/></g:link></li>
         <li><a href="https://bintray.com/grails/plugins"><g:message code="nav.bintray" default="Bintray Repository"/></a></li>
         <li><a href="https://medium.com/@benorama/how-to-publish-your-grails-3-plugin-to-bintray-c341b24f567d"><g:message code="nav.publishingguide" default="Publishing Guide"/></a></li>
         <li><a href="http://blog.agileorbit.com/2015/10/07/Publishing-Grails-3-Plugins.html"><g:message code="nav.publishingfaq" default="Publishing FAQ"/></a></li>


### PR DESCRIPTION
This PR removes the link to the legacy and now deprecated Grails 1&2 plugins portal that will be shutdown soon.

This is how it looks like:

![image](https://user-images.githubusercontent.com/559192/101762531-d6bfa780-3add-11eb-960b-a30009f44d30.png)

Please feel free to change the copy or add a more detailed message.