### PR TITLE
Correct path for oci_home_to_grails.svg

### DIFF
--- a/src/main/groovy/org/grails/pages/Page.groovy
+++ b/src/main/groovy/org/grails/pages/Page.groovy
@@ -182,7 +182,7 @@ abstract class Page implements HtmlPage {
                 div(class: 'ocihometograils') {
                     span 'Sponsored by'
                     a(href: "https://objectcomputing.com/products/grails/") {
-                        img(src: 'assets/oci_home_to_grails.svg', alt: 'Object Computing - Home to Grails', width: '300px')
+                        img(src: '/assets/oci_home_to_grails.svg', alt: 'Object Computing - Home to Grails', width: '300px')
                     }
                 }
                 nav(class: 'socialmedianav') {


### PR DESCRIPTION
Update oci_home_to_grails.svg image path from root instead of relative